### PR TITLE
Make the Company website property nullable

### DIFF
--- a/src/Models/Company.php
+++ b/src/Models/Company.php
@@ -91,7 +91,7 @@ class Company
     /**
      * Get the companies website.
      *
-     * @var string
+     * @var string|null
      */
     protected $website;
 
@@ -322,9 +322,9 @@ class Company
     /**
      * Get the companies website URL.
      *
-     * @return string
+     * @return string|null
      */
-    public function getWebsite(): string
+    public function getWebsite(): ?string
     {
         return $this->website;
     }


### PR DESCRIPTION
This PR makes the company `website` property nullable.

Since it also is nullable in the API itself, requesting a VTC without a website before this PR will throw a `Return value must be of type string, null returned` exception.