### PR TITLE
Fix typos and grammatical errors

### DIFF
--- a/src/Models/Company.php
+++ b/src/Models/Company.php
@@ -26,14 +26,14 @@ class Company
     protected $name;
 
     /**
-     * Get the owners ID.
+     * Get the owner's ID.
      *
      * @var int
      */
     protected $ownerId;
 
     /**
-     * Get the owners name.
+     * Get the owner's name.
      *
      * @var string
      */
@@ -54,14 +54,14 @@ class Company
     protected $tag;
 
     /**
-     * Get the companies logo image URL.
+     * Get the company's logo image URL.
      *
      * @var string
      */
     protected $logo;
 
     /**
-     * Get the companies cover image URL.
+     * Get the company's cover image URL.
      *
      * @var string
      */
@@ -89,14 +89,14 @@ class Company
     protected $requirements;
 
     /**
-     * Get the companies website.
+     * Get the company's website.
      *
      * @var string|null
      */
     protected $website;
 
     /**
-     * Get the companies social information.
+     * Get the company's social information.
      *
      * @var Social
      */
@@ -270,7 +270,7 @@ class Company
     }
 
     /**
-     * Get the URL to the companies logo.
+     * Get the URL to the company's logo.
      *
      * @return string
      */
@@ -280,7 +280,7 @@ class Company
     }
 
     /**
-     * Get the URL to the companies cover image.
+     * Get the URL to the company's cover image.
      *
      * @return string
      */
@@ -300,7 +300,7 @@ class Company
     }
 
     /**
-     * Get the companies rules.
+     * Get the company's rules.
      *
      * @return string
      */
@@ -310,7 +310,7 @@ class Company
     }
 
     /**
-     * Get the companies requirements.
+     * Get the company's requirements.
      *
      * @return string
      */
@@ -320,7 +320,7 @@ class Company
     }
 
     /**
-     * Get the companies website URL.
+     * Get the company's website URL.
      *
      * @return string|null
      */
@@ -330,7 +330,7 @@ class Company
     }
 
     /**
-     * Get the companies social information.
+     * Get the company's social information.
      *
      * @return Social
      */
@@ -360,7 +360,7 @@ class Company
     }
 
     /**
-     * Get the companies recruitment status i.e. Open or Closed.
+     * Get the company's recruitment status i.e. Open or Closed.
      *
      * @return string
      */
@@ -370,7 +370,7 @@ class Company
     }
 
     /**
-     * Get the companies primary language.
+     * Get the company's primary language.
      *
      * @return string
      */

--- a/src/Models/CompanyMember.php
+++ b/src/Models/CompanyMember.php
@@ -7,42 +7,42 @@ use Carbon\Carbon;
 class CompanyMember
 {
     /**
-     * The players member id within the company.
+     * The player's member id within the company.
      *
      * @var int
      */
     protected $id;
 
     /**
-     * The players account id.
+     * The player's account id.
      *
      * @var int
      */
     protected $userId;
 
     /**
-     * The players username.
+     * The player's username.
      *
      * @var string
      */
     protected $username;
 
     /**
-     * The players steam id.
+     * The player's steam id.
      *
      * @var string
      */
     protected $steamId;
 
     /**
-     * The players role id within the company.
+     * The player's role id within the company.
      *
      * @var int
      */
     protected $roleId;
 
     /**
-     * The players role within the company.
+     * The player's role within the company.
      *
      * @var string
      */
@@ -123,7 +123,7 @@ class CompanyMember
     }
 
     /**
-     * Get the name of members role.
+     * Get the name of member's role.
      *
      * @return string
      */

--- a/src/Models/CompanyPost.php
+++ b/src/Models/CompanyPost.php
@@ -19,7 +19,7 @@ class CompanyPost
     protected $title;
 
     /**
-     * A summery of the post content.
+     * A summary of the post content.
      *
      * @var string
      */
@@ -135,7 +135,7 @@ class CompanyPost
     }
 
     /**
-     * Check if the post is pinned on the companies page.
+     * Check if the post is pinned on the company's page.
      *
      * @return bool
      */

--- a/src/Models/Patreon.php
+++ b/src/Models/Patreon.php
@@ -12,7 +12,7 @@ class Patreon
     protected $isPatron;
 
     /**
-     * If the players patron subscription is active.
+     * If the player's patron subscription is active.
      *
      * @var bool
      */
@@ -26,28 +26,28 @@ class Patreon
     protected $color;
 
     /**
-     * The players tier ID.
+     * The player's tier ID.
      *
      * @var int|null
      */
     protected $tierId;
 
     /**
-     * The players current pledge.
+     * The player's current pledge.
      *
      * @var int|null
      */
     protected $currentPledge;
 
     /**
-     * The players lifetime pledge.
+     * The player's lifetime pledge.
      *
      * @var int|null
      */
     protected $lifetimePledge;
 
     /**
-     * The players next pledge.
+     * The player's next pledge.
      *
      * @var int|null
      */
@@ -103,7 +103,7 @@ class Patreon
     }
 
     /**
-     * Get if the players patron subscription is active.
+     * Get if the player's patron subscription is active.
      *
      * @return mixed
      */
@@ -123,7 +123,7 @@ class Patreon
     }
 
     /**
-     * Get the players tier ID.
+     * Get the player's tier ID.
      *
      * @return int|null
      */
@@ -133,7 +133,7 @@ class Patreon
     }
 
     /**
-     * Get the players current pledge.
+     * Get the player's current pledge.
      *
      * @return int|null
      */
@@ -143,7 +143,7 @@ class Patreon
     }
 
     /**
-     * Get the players lifetime pledge.
+     * Get the player's lifetime pledge.
      *
      * @return int|null
      */
@@ -153,7 +153,7 @@ class Patreon
     }
 
     /**
-     * Get the players next pledge.
+     * Get the player's next pledge.
      *
      * @return int|null
      */

--- a/src/Models/Player.php
+++ b/src/Models/Player.php
@@ -70,7 +70,7 @@ class Player
     protected $groupName;
 
     /**
-     * The hex color of the players groups.
+     * The hex color of the player's groups.
      *
      * @var string
      */
@@ -98,7 +98,7 @@ class Player
     protected $displayBans;
 
     /**
-     * Get the players patreon information.
+     * Get the player's patreon information.
      *
      * @var Patreon
      */
@@ -126,21 +126,21 @@ class Player
     protected $inGameAdmin;
 
     /**
-     * The players company ID.
+     * The player's company ID.
      *
      * @var int
      */
     protected $companyId;
 
     /**
-     * The players company name.
+     * The player's company name.
      *
      * @var string
      */
     protected $companyName;
 
     /**
-     * The players company tag.
+     * The player's company tag.
      *
      * @var string
      */
@@ -154,14 +154,14 @@ class Player
     protected $isInCompany;
 
     /**
-     * The players company member id.
+     * The player's company member id.
      *
      * @var int
      */
     protected $companyMemberId;
 
     /**
-     * The players Discord Snowflake.
+     * The player's Discord Snowflake.
      *
      * @var string|null
      */
@@ -211,7 +211,7 @@ class Player
     }
 
     /**
-     * Get the players ID.
+     * Get the player's ID.
      *
      * @return int
      */
@@ -231,7 +231,7 @@ class Player
     }
 
     /**
-     * Get the URL of the players avatar.
+     * Get the URL of the player's avatar.
      *
      * @return string
      */
@@ -241,7 +241,7 @@ class Player
     }
 
     /**
-     * Get the URL of the players small avatar.
+     * Get the URL of the player's small avatar.
      *
      * @return string
      */
@@ -261,7 +261,7 @@ class Player
     }
 
     /**
-     * Get the players Steam ID.
+     * Get the player's Steam ID.
      *
      * @return string
      */
@@ -271,7 +271,7 @@ class Player
     }
 
     /**
-     * Get the players group ID.
+     * Get the player's group ID.
      *
      * @return int
      */
@@ -281,7 +281,7 @@ class Player
     }
 
     /**
-     * Get the name of the players group.
+     * Get the name of the player's group.
      *
      * @return string
      */
@@ -291,7 +291,7 @@ class Player
     }
 
     /**
-     * Get the players group color.
+     * Get the player's group color.
      *
      * @return string
      */
@@ -331,7 +331,7 @@ class Player
     }
 
     /**
-     * Get the players patreon information.
+     * Get the player's patreon information.
      *
      * @return Patreon
      */
@@ -371,7 +371,7 @@ class Player
     }
 
     /**
-     * Get the players company ID.
+     * Get the player's company ID.
      *
      * @return int
      */
@@ -381,7 +381,7 @@ class Player
     }
 
     /**
-     * Get the name of the players company.
+     * Get the name of the player's company.
      *
      * @return string
      */
@@ -391,7 +391,7 @@ class Player
     }
 
     /**
-     * Get the tag of the players company.
+     * Get the tag of the player's company.
      *
      * @return string
      */
@@ -411,7 +411,7 @@ class Player
     }
 
     /**
-     * Get the players company member ID.
+     * Get the player's company member ID.
      *
      * @return int
      */
@@ -421,7 +421,7 @@ class Player
     }
 
     /**
-     * Get the players Discord Snowflake.
+     * Get the player's Discord Snowflake.
      *
      * @return string|null
      */
@@ -431,7 +431,7 @@ class Player
     }
 
     /**
-     * Get the players bans.
+     * Get the player's bans.
      *
      * @return BanCollection
      *
@@ -444,7 +444,7 @@ class Player
     }
 
     /**
-     * Get the players company.
+     * Get the player's company.
      *
      * @return Company|null
      *
@@ -482,7 +482,7 @@ class Player
     }
 
     /**
-     * Get the CompanyRole instance for the players company role.
+     * Get the CompanyRole instance for the player's company role.
      *
      * @return CompanyRole|null
      *

--- a/tests/Unit/CompanyTest.php
+++ b/tests/Unit/CompanyTest.php
@@ -36,7 +36,7 @@ class CompanyTest extends TestCase
     }
 
     /** @test */
-    public function it_can_get_the_fetured_companies()
+    public function it_can_get_the_featured_companies()
     {
         $companies = $this->companies()->getFeatured();
 

--- a/tests/Unit/PlayerTest.php
+++ b/tests/Unit/PlayerTest.php
@@ -196,7 +196,7 @@ class PlayerTest extends TestCase
         $player = $this->player(self::TEST_ACCOUNT);
 
         // We have to check if the Discord Snowflake is null first and then
-        // run a test to assert the value is null. Otherwise the test would
+        // run a test to assert the value is null. Otherwise, the test would
         // fail because no tests would have run.
         if ($player->getDiscordSnowflake() === null) {
             $this->assertNull($player->getDiscordSnowflake());


### PR DESCRIPTION
Fixed all typos and grammatical errors that I could find. Not a super important PR, but improved readability is always nice to see.

### Tl;dr changelog
* Corrected all possessive nouns in docblocks (e.g. "owners" > "owner's", see https://www.grammarly.com/blog/possessive-nouns)
* Fixed "summery" typo
* Added a comma for extra readability
* Fixed a test name typo (`it_can_get_the_fetured_companies`)