### PR TITLE
Implement banned company members endpoint

### DIFF
--- a/src/Collections/Company/BanCollection.php
+++ b/src/Collections/Company/BanCollection.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TruckersMP\APIClient\Collections\Company;
+
+use TruckersMP\APIClient\Collections\Collection;
+use TruckersMP\APIClient\Models\CompanyBan;
+
+class BanCollection extends Collection
+{
+    /**
+     * Create a new BanCollection instance.
+     *
+     * @param  array  $response
+     * @return void
+     */
+    public function __construct(array $response)
+    {
+        parent::__construct();
+
+        foreach ($response['members'] as $key => $ban) {
+            $this->items[$key] = new CompanyBan($ban);
+        }
+    }
+}

--- a/src/Models/CompanyBan.php
+++ b/src/Models/CompanyBan.php
@@ -7,7 +7,7 @@ use Carbon\Carbon;
 class CompanyBan
 {
     /**
-     * The ID of the ban.
+     * The player's member ID within the company.
      *
      * @var int
      */
@@ -35,14 +35,14 @@ class CompanyBan
     protected $steamId;
 
     /**
-     * The role ID of the user.
+     * The player's role ID within the company.
      *
      * @var int
      */
     protected $roleId;
 
     /**
-     * The role name of the user.
+     * The player's role name within the company.
      *
      * @var string
      */
@@ -73,7 +73,7 @@ class CompanyBan
     }
 
     /**
-     * Get the ID of the ban.
+     * Get the player's member ID within the company.
      *
      * @return int
      */
@@ -113,7 +113,7 @@ class CompanyBan
     }
 
     /**
-     * Get the ID of the member's role.
+     * Get the ID of the member's role within the company.
      *
      * @return int
      */
@@ -123,7 +123,7 @@ class CompanyBan
     }
 
     /**
-     * Get the name of the member's role.
+     * Get the name of the member's role within the company.
      *
      * @return string
      */

--- a/src/Models/CompanyBan.php
+++ b/src/Models/CompanyBan.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace TruckersMP\APIClient\Models;
+
+use Carbon\Carbon;
+
+class CompanyBan
+{
+    /**
+     * The ID of the ban.
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * The ID of the user.
+     *
+     * @var int
+     */
+    protected $userId;
+
+    /**
+     * The username of the user.
+     *
+     * @var string
+     */
+    protected $username;
+
+    /**
+     * The Steam ID of the user.
+     *
+     * @var int
+     */
+    protected $steamId;
+
+    /**
+     * The role ID of the user.
+     *
+     * @var int
+     */
+    protected $roleId;
+
+    /**
+     * The role name of the user.
+     *
+     * @var string
+     */
+    protected $roleName;
+
+    /**
+     * The date at which the user joined the company.
+     *
+     * @var Carbon
+     */
+    protected $joinDate;
+
+    /**
+     * Create a new CompanyBan instance.
+     *
+     * @param  array  $ban
+     * @return void
+     */
+    public function __construct(array $ban)
+    {
+        $this->id = $ban['id'];
+        $this->userId = $ban['user_id'];
+        $this->username = $ban['username'];
+        $this->steamId = $ban['steam_id'];
+        $this->roleId = $ban['role_id'];
+        $this->roleName = $ban['role'];
+        $this->joinDate = new Carbon($ban['joinDate'], 'UTC');
+    }
+
+    /**
+     * Get the ID of the ban.
+     *
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the ID of the user.
+     *
+     * @return int
+     */
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    /**
+     * Get the username of the user.
+     *
+     * @return string
+     */
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    /**
+     * Get the Steam ID of the user.
+     *
+     * @return int
+     */
+    public function getSteamId(): int
+    {
+        return $this->steamId;
+    }
+
+    /**
+     * Get the ID of the member's role.
+     *
+     * @return int
+     */
+    public function getRoleId(): int
+    {
+        return $this->roleId;
+    }
+
+    /**
+     * Get the name of the member's role.
+     *
+     * @return string
+     */
+    public function getRoleName(): string
+    {
+        return $this->roleName;
+    }
+
+    /**
+     * Get the date the member joined the company.
+     *
+     * @return Carbon
+     */
+    public function getJoinDate(): Carbon
+    {
+        return $this->joinDate;
+    }
+}

--- a/src/Requests/Company/BanIndexRequest.php
+++ b/src/Requests/Company/BanIndexRequest.php
@@ -11,23 +11,23 @@ use TruckersMP\APIClient\Requests\Request;
 class BanIndexRequest extends Request
 {
     /**
-     * The ID of the requested company.
+     * The ID or slug of the requested company.
      *
-     * @var int
+     * @var string|int
      */
-    protected $companyId;
+    protected $companyKey;
 
     /**
      * Create a new BanIndexRequest instance.
      *
-     * @param  int  $companyId
+     * @param  string|int  $companyKey
      * @return void
      */
-    public function __construct(int $companyId)
+    public function __construct(string $companyKey)
     {
         parent::__construct();
 
-        $this->companyId = $companyId;
+        $this->companyKey = $companyKey;
     }
 
     /**
@@ -37,7 +37,7 @@ class BanIndexRequest extends Request
      */
     public function getEndpoint(): string
     {
-        return 'vtc/' . $this->companyId . '/members/banned';
+        return 'vtc/' . $this->companyKey . '/members/banned';
     }
 
     /**

--- a/src/Requests/Company/BanIndexRequest.php
+++ b/src/Requests/Company/BanIndexRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace TruckersMP\APIClient\Requests\Company;
+
+use Psr\Http\Client\ClientExceptionInterface;
+use TruckersMP\APIClient\Collections\Company\BanCollection;
+use TruckersMP\APIClient\Exceptions\ApiErrorException;
+use TruckersMP\APIClient\Models\CompanyBan;
+use TruckersMP\APIClient\Requests\Request;
+
+class BanIndexRequest extends Request
+{
+    /**
+     * The ID of the requested company.
+     *
+     * @var int
+     */
+    protected $companyId;
+
+    /**
+     * Create a new BanIndexRequest instance.
+     *
+     * @param  int  $companyId
+     * @return void
+     */
+    public function __construct(int $companyId)
+    {
+        parent::__construct();
+
+        $this->companyId = $companyId;
+    }
+
+    /**
+     * Get the endpoint of the request.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return 'vtc/' . $this->companyId . '/members/banned';
+    }
+
+    /**
+     * Get the data for the request.
+     *
+     * @return BanCollection|CompanyBan[]
+     *
+     * @throws ApiErrorException
+     * @throws ClientExceptionInterface
+     */
+    public function get(): BanCollection
+    {
+        return new BanCollection(
+            $this->send()['response']
+        );
+    }
+}

--- a/src/Requests/Company/MemberIndexRequest.php
+++ b/src/Requests/Company/MemberIndexRequest.php
@@ -62,7 +62,7 @@ class MemberIndexRequest extends Request
     public function bans(): BanIndexRequest
     {
         return new BanIndexRequest(
-            $this->companyId
+            $this->companyKey
         );
     }
 }

--- a/src/Requests/Company/MemberIndexRequest.php
+++ b/src/Requests/Company/MemberIndexRequest.php
@@ -53,4 +53,16 @@ class MemberIndexRequest extends Request
             $this->send()['response']
         );
     }
+
+    /**
+     * Get the members within the company that are currently banned.
+     *
+     * @return BanIndexRequest
+     */
+    public function bans(): BanIndexRequest
+    {
+        return new BanIndexRequest(
+            $this->companyId
+        );
+    }
 }

--- a/src/Requests/CompanyRequest.php
+++ b/src/Requests/CompanyRequest.php
@@ -5,6 +5,7 @@ namespace TruckersMP\APIClient\Requests;
 use Psr\Http\Client\ClientExceptionInterface;
 use TruckersMP\APIClient\Exceptions\ApiErrorException;
 use TruckersMP\APIClient\Models\Company;
+use TruckersMP\APIClient\Requests\Company\BanIndexRequest;
 use TruckersMP\APIClient\Requests\Company\MemberIndexRequest;
 use TruckersMP\APIClient\Requests\Company\MemberRequest;
 use TruckersMP\APIClient\Requests\Company\PostIndexRequest;
@@ -136,4 +137,17 @@ class CompanyRequest extends Request
             $id
         );
     }
+
+    /**
+     * Get the banned members in the company.
+     *
+     * @return BanIndexRequest
+     */
+    public function bans(): BanIndexRequest
+    {
+        return new BanIndexRequest(
+            $this->id
+        );
+    }
+
 }

--- a/src/Requests/CompanyRequest.php
+++ b/src/Requests/CompanyRequest.php
@@ -5,7 +5,6 @@ namespace TruckersMP\APIClient\Requests;
 use Psr\Http\Client\ClientExceptionInterface;
 use TruckersMP\APIClient\Exceptions\ApiErrorException;
 use TruckersMP\APIClient\Models\Company;
-use TruckersMP\APIClient\Requests\Company\BanIndexRequest;
 use TruckersMP\APIClient\Requests\Company\MemberIndexRequest;
 use TruckersMP\APIClient\Requests\Company\MemberRequest;
 use TruckersMP\APIClient\Requests\Company\PostIndexRequest;
@@ -135,18 +134,6 @@ class CompanyRequest extends Request
         return new MemberRequest(
             $this->id,
             $id
-        );
-    }
-
-    /**
-     * Get the banned members in the company.
-     *
-     * @return BanIndexRequest
-     */
-    public function bans(): BanIndexRequest
-    {
-        return new BanIndexRequest(
-            $this->id
         );
     }
 }

--- a/src/Requests/CompanyRequest.php
+++ b/src/Requests/CompanyRequest.php
@@ -149,5 +149,4 @@ class CompanyRequest extends Request
             $this->id
         );
     }
-
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,12 +17,14 @@ use Psr\Http\Client\ClientExceptionInterface;
 use ReflectionException;
 use TruckersMP\APIClient\Client;
 use TruckersMP\APIClient\Collections\BanCollection;
+use TruckersMP\APIClient\Collections\Company\BanCollection as CompanyBanCollection;
 use TruckersMP\APIClient\Collections\Company\PostCollection;
 use TruckersMP\APIClient\Collections\Company\RoleCollection;
 use TruckersMP\APIClient\Collections\ServerCollection;
 use TruckersMP\APIClient\Exceptions\ApiErrorException;
 use TruckersMP\APIClient\Models\Ban;
 use TruckersMP\APIClient\Models\Company;
+use TruckersMP\APIClient\Models\CompanyBan;
 use TruckersMP\APIClient\Models\CompanyIndex;
 use TruckersMP\APIClient\Models\CompanyMember;
 use TruckersMP\APIClient\Models\CompanyMemberIndex;
@@ -402,6 +404,30 @@ class TestCase extends BaseTestCase
         }
 
         return $cachedMember->get();
+    }
+
+    /**
+     * Get the banned members for the specified company.
+     *
+     * @param  int  $id
+     *
+     * @return CompanyBanCollection|CompanyBan[]
+     *
+     * @throws PhpfastcacheInvalidArgumentException
+     * @throws ApiErrorException
+     * @throws ClientExceptionInterface
+     * @throws InvalidArgumentException
+     */
+    public function companyBans(int $id): CompanyBanCollection
+    {
+        $cachedCompanyBans = self::$cache->getItem('company_bans_' . $id);
+
+        if (!$cachedCompanyBans->isHit()) {
+            $cachedCompanyBans->set($this->client->company($id)->bans()->get())->expiresAfter(self::CACHE_SECONDS);
+            self::$cache->save($cachedCompanyBans);
+        }
+
+        return $cachedCompanyBans->get();
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -403,7 +403,6 @@ class TestCase extends BaseTestCase
      * Get the members within the specified company that are currently banned.
      *
      * @param  int  $id
-     *
      * @return CompanyBanCollection|CompanyBan[]
      *
      * @throws PhpfastcacheInvalidArgumentException

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -407,7 +407,7 @@ class TestCase extends BaseTestCase
     }
 
     /**
-     * Get the banned members for the specified company.
+     * Get the members within the specified company that are currently banned.
      *
      * @param  int  $id
      *
@@ -423,7 +423,7 @@ class TestCase extends BaseTestCase
         $cachedCompanyBans = self::$cache->getItem('company_bans_' . $id);
 
         if (!$cachedCompanyBans->isHit()) {
-            $cachedCompanyBans->set($this->client->company($id)->bans()->get())->expiresAfter(self::CACHE_SECONDS);
+            $cachedCompanyBans->set($this->client->company($id)->members()->bans()->get())->expiresAfter(self::CACHE_SECONDS);
             self::$cache->save($cachedCompanyBans);
         }
 

--- a/tests/Unit/CompanyBanTest.php
+++ b/tests/Unit/CompanyBanTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use TruckersMP\APIClient\Collections\Company\BanCollection;
+use TruckersMP\APIClient\Models\CompanyBan;
+
+class CompanyBanTest extends TestCase
+{
+    /**
+     * The ID of the company to use in the tests.
+     */
+    private const TEST_COMPANY = 2;
+
+    /** @test */
+    public function it_can_get_all_the_bans()
+    {
+        $bans = $this->companyBans(self::TEST_COMPANY);
+
+        $this->assertInstanceOf(BanCollection::class, $bans);
+
+        if ($bans->count() > 0) {
+            $ban = $bans[0];
+
+            $this->assertInstanceOf(CompanyBan::class, $ban);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for the `vtc/VTCID/members/banned` endpoint.

If this functionality needs to be tested physically, VTCID `10` has two banned members currently.