### PR TITLE
Allow searching with company slug

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -98,10 +98,10 @@ class Client
      *
      * https://stats.truckersmp.com/api#vtc_info
      *
-     * @param  int  $id
+     * @param  string|int  $id
      * @return CompanyRequest
      */
-    public function company(int $id): CompanyRequest
+    public function company(string $id): CompanyRequest
     {
         return new CompanyRequest($id);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -94,16 +94,16 @@ class Client
     }
 
     /**
-     * Get the information for the company with the specified ID.
+     * Get the information for the company with the specified ID or slug.
      *
      * https://stats.truckersmp.com/api#vtc_info
      *
-     * @param  string|int  $id
+     * @param  string|int  $key
      * @return CompanyRequest
      */
-    public function company(string $id): CompanyRequest
+    public function company(string $key): CompanyRequest
     {
-        return new CompanyRequest($id);
+        return new CompanyRequest($key);
     }
 
     /**

--- a/src/Requests/Company/MemberIndexRequest.php
+++ b/src/Requests/Company/MemberIndexRequest.php
@@ -12,17 +12,17 @@ class MemberIndexRequest extends Request
     /**
      * The ID of the requested company.
      *
-     * @var int
+     * @var string|int
      */
     protected $companyId;
 
     /**
      * Create a new MemberIndexRequest instance.
      *
-     * @param  int  $id
+     * @param  string|int  $id
      * @return void
      */
-    public function __construct(int $id)
+    public function __construct(string $id)
     {
         parent::__construct();
 

--- a/src/Requests/Company/MemberIndexRequest.php
+++ b/src/Requests/Company/MemberIndexRequest.php
@@ -19,14 +19,14 @@ class MemberIndexRequest extends Request
     /**
      * Create a new MemberIndexRequest instance.
      *
-     * @param  string|int  $id
+     * @param  string|int  $companyKey
      * @return void
      */
-    public function __construct(string $id)
+    public function __construct(string $companyKey)
     {
         parent::__construct();
 
-        $this->companyKey = $id;
+        $this->companyKey = $companyKey;
     }
 
     /**

--- a/src/Requests/Company/MemberIndexRequest.php
+++ b/src/Requests/Company/MemberIndexRequest.php
@@ -10,11 +10,11 @@ use TruckersMP\APIClient\Requests\Request;
 class MemberIndexRequest extends Request
 {
     /**
-     * The ID of the requested company.
+     * The ID or slug of the requested company.
      *
      * @var string|int
      */
-    protected $companyId;
+    protected $companyKey;
 
     /**
      * Create a new MemberIndexRequest instance.
@@ -26,7 +26,7 @@ class MemberIndexRequest extends Request
     {
         parent::__construct();
 
-        $this->companyId = $id;
+        $this->companyKey = $id;
     }
 
     /**
@@ -36,7 +36,7 @@ class MemberIndexRequest extends Request
      */
     public function getEndpoint(): string
     {
-        return 'vtc/' . $this->companyId . '/members';
+        return 'vtc/' . $this->companyKey . '/members';
     }
 
     /**

--- a/src/Requests/Company/MemberRequest.php
+++ b/src/Requests/Company/MemberRequest.php
@@ -10,11 +10,11 @@ use TruckersMP\APIClient\Requests\Request;
 class MemberRequest extends Request
 {
     /**
-     * The ID of the requested company.
+     * The ID or slug of the requested company.
      *
      * @var string|int
      */
-    protected $companyId;
+    protected $companyKey;
 
     /**
      * The ID of the requested member.
@@ -26,15 +26,15 @@ class MemberRequest extends Request
     /**
      * Create a new MemberRequest instance.
      *
-     * @param  string|int  $companyId
+     * @param  string|int  $companyKey
      * @param  int  $memberId
      * @return void
      */
-    public function __construct(string $companyId, int $memberId)
+    public function __construct(string $companyKey, int $memberId)
     {
         parent::__construct();
 
-        $this->companyId = $companyId;
+        $this->companyKey = $companyKey;
         $this->memberId = $memberId;
     }
 
@@ -45,7 +45,7 @@ class MemberRequest extends Request
      */
     public function getEndpoint(): string
     {
-        return 'vtc/' . $this->companyId . '/member/' . $this->memberId;
+        return 'vtc/' . $this->companyKey . '/member/' . $this->memberId;
     }
 
     /**

--- a/src/Requests/Company/MemberRequest.php
+++ b/src/Requests/Company/MemberRequest.php
@@ -12,7 +12,7 @@ class MemberRequest extends Request
     /**
      * The ID of the requested company.
      *
-     * @var int
+     * @var string|int
      */
     protected $companyId;
 
@@ -26,11 +26,11 @@ class MemberRequest extends Request
     /**
      * Create a new MemberRequest instance.
      *
-     * @param  int  $companyId
+     * @param  string|int  $companyId
      * @param  int  $memberId
      * @return void
      */
-    public function __construct(int $companyId, int $memberId)
+    public function __construct(string $companyId, int $memberId)
     {
         parent::__construct();
 

--- a/src/Requests/Company/PostIndexRequest.php
+++ b/src/Requests/Company/PostIndexRequest.php
@@ -13,17 +13,17 @@ class PostIndexRequest extends Request
     /**
      * The ID of the requested company.
      *
-     * @var int
+     * @var string|int
      */
     protected $companyId;
 
     /**
      * Create a new PostIndexRequest instance.
      *
-     * @param  int  $companyId
+     * @param  string|int  $companyId
      * @return void
      */
-    public function __construct(int $companyId)
+    public function __construct(string $companyId)
     {
         parent::__construct();
 

--- a/src/Requests/Company/PostIndexRequest.php
+++ b/src/Requests/Company/PostIndexRequest.php
@@ -11,23 +11,23 @@ use TruckersMP\APIClient\Requests\Request;
 class PostIndexRequest extends Request
 {
     /**
-     * The ID of the requested company.
+     * The ID or slug of the requested company.
      *
      * @var string|int
      */
-    protected $companyId;
+    protected $companyKey;
 
     /**
      * Create a new PostIndexRequest instance.
      *
-     * @param  string|int  $companyId
+     * @param  string|int  $companyKey
      * @return void
      */
-    public function __construct(string $companyId)
+    public function __construct(string $companyKey)
     {
         parent::__construct();
 
-        $this->companyId = $companyId;
+        $this->companyKey = $companyKey;
     }
 
     /**
@@ -37,7 +37,7 @@ class PostIndexRequest extends Request
      */
     public function getEndpoint(): string
     {
-        return 'vtc/' . $this->companyId . '/news';
+        return 'vtc/' . $this->companyKey . '/news';
     }
 
     /**

--- a/src/Requests/Company/PostRequest.php
+++ b/src/Requests/Company/PostRequest.php
@@ -12,7 +12,7 @@ class PostRequest extends Request
     /**
      * The ID of the requested company.
      *
-     * @var int
+     * @var string|int
      */
     protected $companyId;
 
@@ -26,11 +26,11 @@ class PostRequest extends Request
     /**
      * Create a new PostRequest instance.
      *
-     * @param  int  $companyId
+     * @param  string|int  $companyId
      * @param  int  $postId
      * @return void
      */
-    public function __construct(int $companyId, int $postId)
+    public function __construct(string $companyId, int $postId)
     {
         parent::__construct();
 

--- a/src/Requests/Company/PostRequest.php
+++ b/src/Requests/Company/PostRequest.php
@@ -10,11 +10,11 @@ use TruckersMP\APIClient\Requests\Request;
 class PostRequest extends Request
 {
     /**
-     * The ID of the requested company.
+     * The ID or slug of the requested company.
      *
      * @var string|int
      */
-    protected $companyId;
+    protected $companyKey;
 
     /**
      * The ID of the requested post.
@@ -26,15 +26,15 @@ class PostRequest extends Request
     /**
      * Create a new PostRequest instance.
      *
-     * @param  string|int  $companyId
+     * @param  string|int  $companyKey
      * @param  int  $postId
      * @return void
      */
-    public function __construct(string $companyId, int $postId)
+    public function __construct(string $companyKey, int $postId)
     {
         parent::__construct();
 
-        $this->companyId = $companyId;
+        $this->companyKey = $companyKey;
         $this->postId = $postId;
     }
 
@@ -45,7 +45,7 @@ class PostRequest extends Request
      */
     public function getEndpoint(): string
     {
-        return 'vtc/' . $this->companyId . '/news/' . $this->postId;
+        return 'vtc/' . $this->companyKey . '/news/' . $this->postId;
     }
 
     /**

--- a/src/Requests/Company/RoleIndexRequest.php
+++ b/src/Requests/Company/RoleIndexRequest.php
@@ -13,17 +13,17 @@ class RoleIndexRequest extends Request
     /**
      * The ID of the requested company.
      *
-     * @var int
+     * @var string|int
      */
     protected $companyId;
 
     /**
      * Create a new RoleIndexRequest instance.
      *
-     * @param  int  $companyId
+     * @param  string|int  $companyId
      * @return void
      */
-    public function __construct(int $companyId)
+    public function __construct(string $companyId)
     {
         parent::__construct();
 

--- a/src/Requests/Company/RoleIndexRequest.php
+++ b/src/Requests/Company/RoleIndexRequest.php
@@ -11,23 +11,23 @@ use TruckersMP\APIClient\Requests\Request;
 class RoleIndexRequest extends Request
 {
     /**
-     * The ID of the requested company.
+     * The ID or slug of the requested company.
      *
      * @var string|int
      */
-    protected $companyId;
+    protected $companyKey;
 
     /**
      * Create a new RoleIndexRequest instance.
      *
-     * @param  string|int  $companyId
+     * @param  string|int  $companyKey
      * @return void
      */
-    public function __construct(string $companyId)
+    public function __construct(string $companyKey)
     {
         parent::__construct();
 
-        $this->companyId = $companyId;
+        $this->companyKey = $companyKey;
     }
 
     /**
@@ -37,7 +37,7 @@ class RoleIndexRequest extends Request
      */
     public function getEndpoint(): string
     {
-        return 'vtc/' . $this->companyId . '/roles';
+        return 'vtc/' . $this->companyKey . '/roles';
     }
 
     /**

--- a/src/Requests/Company/RoleRequest.php
+++ b/src/Requests/Company/RoleRequest.php
@@ -11,11 +11,11 @@ use TruckersMP\APIClient\Requests\Request;
 class RoleRequest extends Request
 {
     /**
-     * The ID of the requested company.
+     * The ID or slug of the requested company.
      *
-     * @var int
+     * @var string|int
      */
-    protected $companyId;
+    protected $companyKey;
 
     /**
      * The ID of the requested role.
@@ -27,15 +27,15 @@ class RoleRequest extends Request
     /**
      * Create a new RoleRequest instance.
      *
-     * @param  int  $companyId
+     * @param  int  $companyKey
      * @param  int  $roleId
      * @return void
      */
-    public function __construct(int $companyId, int $roleId)
+    public function __construct(int $companyKey, int $roleId)
     {
         parent::__construct();
 
-        $this->companyId = $companyId;
+        $this->companyKey = $companyKey;
         $this->roleId = $roleId;
     }
 
@@ -46,7 +46,7 @@ class RoleRequest extends Request
      */
     public function getEndpoint(): string
     {
-        return 'vtc/' . $this->companyId . '/role/' . $this->roleId;
+        return 'vtc/' . $this->companyKey . '/role/' . $this->roleId;
     }
 
     /**

--- a/src/Requests/CompanyRequest.php
+++ b/src/Requests/CompanyRequest.php
@@ -15,23 +15,23 @@ use TruckersMP\APIClient\Requests\Company\RoleRequest;
 class CompanyRequest extends Request
 {
     /**
-     * The ID of the requested company.
+     * The ID or slug of the requested company.
      *
      * @var string|int
      */
-    protected $id;
+    protected $key;
 
     /**
      * Create a new CompanyRequest instance.
      *
-     * @param  string|int  $id
+     * @param  string|int  $key
      * @return void
      */
-    public function __construct(string $id)
+    public function __construct(string $key)
     {
         parent::__construct();
 
-        $this->id = $id;
+        $this->key = $key;
     }
 
     /**
@@ -41,7 +41,7 @@ class CompanyRequest extends Request
      */
     public function getEndpoint(): string
     {
-        return 'vtc/' . $this->id;
+        return 'vtc/' . $this->key;
     }
 
     /**
@@ -67,7 +67,7 @@ class CompanyRequest extends Request
     public function posts(): PostIndexRequest
     {
         return new PostIndexRequest(
-            $this->id
+            $this->key
         );
     }
 
@@ -80,7 +80,7 @@ class CompanyRequest extends Request
     public function post(int $id): PostRequest
     {
         return new PostRequest(
-            $this->id,
+            $this->key,
             $id
         );
     }
@@ -93,7 +93,7 @@ class CompanyRequest extends Request
     public function roles(): RoleIndexRequest
     {
         return new RoleIndexRequest(
-            $this->id
+            $this->key
         );
     }
 
@@ -106,7 +106,7 @@ class CompanyRequest extends Request
     public function role(int $id): RoleRequest
     {
         return new RoleRequest(
-            $this->id,
+            $this->key,
             $id
         );
     }
@@ -119,7 +119,7 @@ class CompanyRequest extends Request
     public function members(): MemberIndexRequest
     {
         return new MemberIndexRequest(
-            $this->id
+            $this->key
         );
     }
 
@@ -132,7 +132,7 @@ class CompanyRequest extends Request
     public function member(int $id): MemberRequest
     {
         return new MemberRequest(
-            $this->id,
+            $this->key,
             $id
         );
     }

--- a/src/Requests/CompanyRequest.php
+++ b/src/Requests/CompanyRequest.php
@@ -17,17 +17,17 @@ class CompanyRequest extends Request
     /**
      * The ID of the requested company.
      *
-     * @var int
+     * @var string|int
      */
     protected $id;
 
     /**
      * Create a new CompanyRequest instance.
      *
-     * @param  int  $id
+     * @param  string|int  $id
      * @return void
      */
-    public function __construct(int $id)
+    public function __construct(string $id)
     {
         parent::__construct();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -224,7 +224,7 @@ class TestCase extends BaseTestCase
     /**
      * Get or cache the company with the specified id.
      *
-     * @param  int  $id
+     * @param  string|int  $id
      *
      * @return Company
      *
@@ -233,7 +233,7 @@ class TestCase extends BaseTestCase
      * @throws ClientExceptionInterface
      * @throws InvalidArgumentException
      */
-    public function company(int $id): Company
+    public function company(string $id): Company
     {
         $cachedCompany = self::$cache->getItem('company_' . $id);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -222,9 +222,9 @@ class TestCase extends BaseTestCase
     }
 
     /**
-     * Get or cache the company with the specified id.
+     * Get or cache the company with the specified id or slug.
      *
-     * @param  string|int  $id
+     * @param  string|int  $key
      *
      * @return Company
      *
@@ -233,12 +233,12 @@ class TestCase extends BaseTestCase
      * @throws ClientExceptionInterface
      * @throws InvalidArgumentException
      */
-    public function company(string $id): Company
+    public function company(string $key): Company
     {
-        $cachedCompany = self::$cache->getItem('company_' . $id);
+        $cachedCompany = self::$cache->getItem('company_' . $key);
 
         if (!$cachedCompany->isHit()) {
-            $cachedCompany->set($this->client->company($id)->get())->expiresAfter(self::CACHE_SECONDS);
+            $cachedCompany->set($this->client->company($key)->get())->expiresAfter(self::CACHE_SECONDS);
             self::$cache->save($cachedCompany);
         }
 

--- a/tests/Unit/CompanyTest.php
+++ b/tests/Unit/CompanyTest.php
@@ -15,7 +15,9 @@ class CompanyTest extends TestCase
     /**
      * The ID of the company to use in the tests.
      */
-    private const TEST_COMPANY = 1;
+    private const TEST_COMPANY_ID = 1;
+
+    private const TEST_COMPANY_SLUG = 'phoenix';
 
     /** @test */
     public function it_can_get_all_the_companies()
@@ -56,9 +58,17 @@ class CompanyTest extends TestCase
     }
 
     /** @test */
-    public function it_can_get_a_specific_company()
+    public function it_can_get_a_specific_company_with_id()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
+
+        $this->assertInstanceOf(Company::class, $company);
+    }
+
+    /** @test */
+    public function it_can_get_a_specific_company_with_slug()
+    {
+        $company = $this->company(self::TEST_COMPANY_SLUG);
 
         $this->assertInstanceOf(Company::class, $company);
     }
@@ -66,7 +76,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_an_id()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsInt($company->getId());
     }
@@ -74,7 +84,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_a_name()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsString($company->getName());
     }
@@ -82,7 +92,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_an_owner_id()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsInt($company->getOwnerId());
     }
@@ -90,7 +100,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_an_owner_name()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsString($company->getOwnerName());
     }
@@ -98,7 +108,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_a_slogan()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsString($company->getSlogan());
     }
@@ -106,7 +116,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_a_tag()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsString($company->getTag());
     }
@@ -114,7 +124,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_a_cover()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsString($company->getCover());
     }
@@ -122,7 +132,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_a_logo()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsString($company->getLogo());
     }
@@ -130,7 +140,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_information()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsString($company->getInformation());
     }
@@ -138,7 +148,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_rules()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsString($company->getRules());
     }
@@ -146,7 +156,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_requirements()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsString($company->getRequirements());
     }
@@ -154,7 +164,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_a_website()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsString($company->getWebsite());
     }
@@ -162,7 +172,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_social_media_information()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertInstanceOf(Social::class, $company->getSocial());
 
@@ -195,7 +205,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_supported_games()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertInstanceOf(Game::class, $company->getGames());
 
@@ -206,7 +216,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_a_member_count()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsInt($company->getMembersCount());
     }
@@ -214,7 +224,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_a_recruitment_state()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsString($company->getRecruitment());
 
@@ -225,7 +235,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_a_language()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsString($company->getLanguage());
     }
@@ -233,7 +243,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function if_it_is_verified()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsBool($company->isVerified());
     }
@@ -241,7 +251,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function if_it_is_validate()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertIsBool($company->isValidated());
     }
@@ -249,7 +259,7 @@ class CompanyTest extends TestCase
     /** @test */
     public function it_has_a_created_at_test()
     {
-        $company = $this->company(self::TEST_COMPANY);
+        $company = $this->company(self::TEST_COMPANY_ID);
 
         $this->assertInstanceOf(Carbon::class, $company->getCreatedDate());
     }


### PR DESCRIPTION
Currently, it already is a possibility to search by company slug in the API. E.g. `https://api.truckersmp.com/v2/vtc/phoenix`. However, because of the type declarations in this package code, this wasn't an option here yet.

This PR resolves that issue, including a test that checks the functionality with a company slug.

Sadly, because this package isn't PHP ^8.0, declaring the property types as `int|string` wasn't possible. However, declaring them as a string shouldn't be a problem because of [type juggling](https://www.php.net/manual/en/language.types.type-juggling.php). And they are declared as `string|int` in the DocBlocks.

This should all work as expected, with both slugs and integer IDs, but let me know if there is any feedback.