### PR TITLE
Add active ban count to Player model

### DIFF
--- a/src/Models/Player.php
+++ b/src/Models/Player.php
@@ -91,7 +91,7 @@ class Player
     protected $bannedUntil;
 
     /**
-     * The number of active bans a user has or null if staff.
+     * The number of active bans a user has, or null if staff.
      *
      * @var int|null
      */

--- a/src/Models/Player.php
+++ b/src/Models/Player.php
@@ -91,6 +91,13 @@ class Player
     protected $bannedUntil;
 
     /**
+     * The number of active bans a user has or null if staff.
+     *
+     * @var int|null
+     */
+    protected $activeBanCount;
+
+    /**
      * If the user has their bans hidden.
      *
      * @var bool
@@ -186,6 +193,7 @@ class Player
         $this->groupColor = $player['groupColor'];
         $this->isBanned = $player['banned'];
         $this->bannedUntil = new Carbon($player['bannedUntil'], 'UTC');
+        $this->activeBanCount = $player['bansCount'];
         $this->displayBans = $player['displayBans'];
 
         $this->patreon = new Patreon(
@@ -318,6 +326,16 @@ class Player
     public function getBannedUntilDate(): ?Carbon
     {
         return $this->bannedUntil;
+    }
+
+    /**
+     * Get the player's number of active bans, or null if staff.
+     *
+     * @return int|null
+     */
+    public function getActiveBanCount(): ?int
+    {
+        return $this->activeBanCount;
     }
 
     /**

--- a/tests/Unit/PlayerTest.php
+++ b/tests/Unit/PlayerTest.php
@@ -111,6 +111,18 @@ class PlayerTest extends TestCase
     }
 
     /** @test */
+    public function it_has_an_active_ban_count()
+    {
+        $player = $this->player(self::TEST_ACCOUNT);
+
+        if ($player->isStaff()) {
+            $this->assertNull($player->getActiveBanCount());
+        } else {
+            $this->assertIsInt($player->getActiveBanCount());
+        }
+    }
+
+    /** @test */
     public function if_it_has_bans_hidden()
     {
         $player = $this->player(self::TEST_ACCOUNT);


### PR DESCRIPTION
This PR adds support for the `bansCount` property the API player endpoint returns.