### PR TITLE
Add map ID to Server model

### DIFF
--- a/src/Models/Server.php
+++ b/src/Models/Server.php
@@ -82,6 +82,13 @@ class Server
     protected $maxPlayers;
 
     /**
+     * The map ID given to the server used by ETS2Map.
+     *
+     * @var int
+     */
+    protected $mapId;
+
+    /**
      * Determines the order in which servers are displayed.
      *
      * @var int
@@ -170,6 +177,7 @@ class Server
         $this->players = intval($server['players']);
         $this->queue = intval($server['queue']);
         $this->maxPlayers = intval($server['maxplayers']);
+        $this->mapId = intval($server['mapid']);
         $this->displayOrder = intval($server['displayorder']);
         $this->speedLimiter = boolval($server['speedlimiter']);
         $this->collisions = boolval($server['collisions']);
@@ -290,6 +298,16 @@ class Server
     public function getMaxPlayers(): int
     {
         return $this->maxPlayers;
+    }
+
+    /**
+     * Get the map ID given to the server used by ETS2Map.
+     *
+     * @return int
+     */
+    public function getMapId(): int
+    {
+        return $this->mapId;
     }
 
     /**

--- a/tests/Unit/ServerTest.php
+++ b/tests/Unit/ServerTest.php
@@ -113,6 +113,14 @@ class ServerTest extends TestCase
     }
 
     /** @test */
+    public function it_has_a_map_id()
+    {
+        $server = $this->servers()[0];
+
+        $this->assertIsInt($server->getMapId());
+    }
+
+    /** @test */
     public function it_has_a_display_order()
     {
         $server = $this->servers()[0];


### PR DESCRIPTION
This PR adds support for the `mapid` property the API servers endpoint returns.