### PR TITLE
Add `is_owner` field to `CompanyMember`

### DIFF
--- a/src/Models/CompanyMember.php
+++ b/src/Models/CompanyMember.php
@@ -50,6 +50,13 @@ class CompanyMember extends Model
     protected string $role;
 
     /**
+     * If the member has owner permissions.
+     *
+     * @var bool
+     */
+    protected bool $owner;
+
+    /**
      * The date the player joined the company.
      *
      * @var Carbon
@@ -73,6 +80,7 @@ class CompanyMember extends Model
         $this->steamId = (string) $this->getValue('steam_id');
         $this->roleId = $this->getValue('role_id');
         $this->role = $this->getValue('role');
+        $this->owner = $this->getValue('is_owner', false);
         $this->joinDate = new Carbon($this->getValue('joinDate'), 'UTC');
     }
 
@@ -134,6 +142,16 @@ class CompanyMember extends Model
     public function getRole(): string
     {
         return $this->role;
+    }
+
+    /**
+     * Check whether the member has owner permissions.
+     *
+     * @return bool
+     */
+    public function isOwner(): bool
+    {
+        return $this->owner;
     }
 
     /**

--- a/tests/Unit/Models/CompanyMemberTest.php
+++ b/tests/Unit/Models/CompanyMemberTest.php
@@ -47,6 +47,11 @@ class CompanyMemberTest extends TestCase
         $this->assertSame('Role', $this->member->getRole());
     }
 
+    public function testItHasOwnerPermissions()
+    {
+        $this->assertTrue($this->member->isOwner());
+    }
+
     public function testItHasAJoinDate()
     {
         $this->assertDate('2023-01-04 11:35:05', $this->member->getJoinDate());

--- a/tests/Unit/Models/fixtures/company.member.json
+++ b/tests/Unit/Models/fixtures/company.member.json
@@ -5,5 +5,6 @@
     "steam_id": 76561198083585955,
     "role_id": 25,
     "role": "Role",
+    "is_owner": true,
     "joinDate": "2023-01-04 11:35:05"
 }

--- a/tests/Unit/Requests/fixtures/company.ban.json
+++ b/tests/Unit/Requests/fixtures/company.ban.json
@@ -9,6 +9,7 @@
                 "steam_id": 76561198083585955,
                 "role_id": 25,
                 "role": "Role",
+                "is_owner": true,
                 "joinDate": "2023-01-04 11:35:05"
             }
         ],

--- a/tests/Unit/Requests/fixtures/company.member.index.json
+++ b/tests/Unit/Requests/fixtures/company.member.index.json
@@ -9,6 +9,7 @@
                 "steam_id": 76561198083585955,
                 "role_id": 25,
                 "role": "Role",
+                "is_owner": true,
                 "joinDate": "2023-01-04 11:35:05"
             }
         ],

--- a/tests/Unit/Requests/fixtures/company.member.json
+++ b/tests/Unit/Requests/fixtures/company.member.json
@@ -7,6 +7,7 @@
         "steam_id": 76561198083585955,
         "role_id": 25,
         "role": "Role",
+        "is_owner": true,
         "joinDate": "2023-01-04 11:35:05"
     }
 }


### PR DESCRIPTION
Adds support for a field that describes whether a company member has owner permissions.