### PR TITLE
Add user events

### DIFF
--- a/src/Models/Player.php
+++ b/src/Models/Player.php
@@ -11,6 +11,7 @@ use TruckersMP\APIClient\Requests\BanRequest;
 use TruckersMP\APIClient\Requests\Company\MemberRequest;
 use TruckersMP\APIClient\Requests\Company\RoleRequest;
 use TruckersMP\APIClient\Requests\CompanyRequest;
+use TruckersMP\APIClient\Requests\EventUserRequest;
 
 class Player extends Model
 {
@@ -470,6 +471,24 @@ class Player extends Model
     public function getBans(): Collection
     {
         return (new BanRequest($this->client, $this->id))->get();
+    }
+
+    /**
+     * Get events created by the player.
+     *
+     * @return Collection
+     *
+     * @throws ApiErrorException
+     * @throws ClientExceptionInterface
+     */
+    public function getEvents(): Collection
+    {
+        $request = new EventUserRequest(
+            $this->client,
+            $this->id,
+        );
+
+        return $request->get();
     }
 
     /**

--- a/src/Requests/EventUserRequest.php
+++ b/src/Requests/EventUserRequest.php
@@ -49,7 +49,7 @@ class EventUserRequest extends Request
      * @throws ClientExceptionInterface
      * @throws ApiErrorException
      */
-    public function get()
+    public function get(): Collection
     {
         return (new Collection($this->send()['response']))
             ->map(fn (array $event) => new Event($this->client, $event));

--- a/src/Requests/EventUserRequest.php
+++ b/src/Requests/EventUserRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace TruckersMP\APIClient\Requests;
+
+use Illuminate\Support\Collection;
+use Psr\Http\Client\ClientExceptionInterface;
+use TruckersMP\APIClient\Client;
+use TruckersMP\APIClient\Exceptions\ApiErrorException;
+use TruckersMP\APIClient\Models\Event;
+
+class EventUserRequest extends Request
+{
+    /**
+     * The ID of the requested user.
+     *
+     * @var int
+     */
+    protected int $userId;
+
+    /**
+     * Create a new EventUserRequest instance.
+     *
+     * @param  Client  $client
+     * @param  int  $userId
+     * @return void
+     */
+    public function __construct(Client $client, int $userId)
+    {
+        parent::__construct($client);
+
+        $this->userId = $userId;
+    }
+
+    /**
+     * Get the endpoint of the request.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return 'events/user/' . $this->userId;
+    }
+
+    /**
+     * Get the data for the request.
+     *
+     * @return Collection
+     *
+     * @throws ClientExceptionInterface
+     * @throws ApiErrorException
+     */
+    public function get()
+    {
+        return (new Collection($this->send()['response']))
+            ->map(fn (array $event) => new Event($this->client, $event));
+    }
+}

--- a/src/Requests/PlayerRequest.php
+++ b/src/Requests/PlayerRequest.php
@@ -68,4 +68,17 @@ class PlayerRequest extends Request
             $this->id
         );
     }
+
+    /**
+     * Get all events created by the player.
+     *
+     * @return EventUserRequest
+     */
+    public function events(): EventUserRequest
+    {
+        return new EventUserRequest(
+            $this->client,
+            $this->id,
+        );
+    }
 }

--- a/tests/Unit/Models/PlayerTest.php
+++ b/tests/Unit/Models/PlayerTest.php
@@ -9,6 +9,7 @@ use Tests\Unit\MockModelData;
 use TruckersMP\APIClient\Models\Ban;
 use TruckersMP\APIClient\Models\Company;
 use TruckersMP\APIClient\Models\CompanyMember;
+use TruckersMP\APIClient\Models\Event;
 use TruckersMP\APIClient\Models\Patreon;
 use TruckersMP\APIClient\Models\Player;
 
@@ -122,6 +123,18 @@ class PlayerTest extends TestCase
         $this->assertNotEmpty($bans);
 
         $this->assertInstanceOf(Ban::class, $bans->first());
+    }
+
+    public function testItCanGetEvents()
+    {
+        $this->mockRequest('event.user.json', 'events/user/1287455');
+
+        $events = $this->player->getEvents();
+
+        $this->assertInstanceOf(Collection::class, $events);
+        $this->assertNotEmpty($events);
+
+        $this->assertInstanceOf(Event::class, $events->first());
     }
 
     public function testItCanGetACompany()

--- a/tests/Unit/Requests/EventUserRequestTest.php
+++ b/tests/Unit/Requests/EventUserRequestTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\Requests;
+
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+use Tests\Unit\MockAPIRequests;
+use TruckersMP\APIClient\Models\Event;
+
+class EventUserRequestTest extends TestCase
+{
+    use MockAPIRequests;
+
+    public function testItCanGetUserEvents()
+    {
+        $this->mockRequest('event.user.json', 'events/user/1287455');
+
+        $events = $this->client->player(1287455)->events()->get();
+
+        $this->assertInstanceOf(Collection::class, $events);
+        $this->assertCount(1, $events);
+
+        $this->assertInstanceOf(Event::class, $events->first());
+    }
+}

--- a/tests/Unit/Requests/fixtures/event.user.json
+++ b/tests/Unit/Requests/fixtures/event.user.json
@@ -1,0 +1,53 @@
+{
+    "error": false,
+    "response": [
+        {
+            "id": 777,
+            "event_type": {
+                "key": "convoy",
+                "name": "Convoy"
+            },
+            "name": "February Convoy",
+            "slug": "777-february-convoy",
+            "game": "ETS2",
+            "server": {
+                "id": 66,
+                "name": "Event Server"
+            },
+            "language": "English",
+            "departure": {
+                "location": "Hotel",
+                "city": "Groningen"
+            },
+            "arrive": {
+                "location": "City",
+                "city": "Verona"
+            },
+            "start_at": "2023-02-19 18:30:00",
+            "banner": "https://static.truckersmp.com/images/event/cover/cover.png",
+            "map": "https://static.truckersmp.com/images/event/map/map.png",
+            "description": "Description",
+            "rule": "Rules",
+            "voice_link": "https://discord.gg/truckersmp",
+            "external_link": "https://truckersmp.com",
+            "featured": "Featured",
+            "vtc": {
+                "id": 0,
+                "name": null
+            },
+            "user": {
+                "id": 1287455,
+                "username": "Name"
+            },
+            "attendances": {
+                "confirmed": 228,
+                "unsure": 53,
+                "vtcs": 32
+            },
+            "dlcs": [],
+            "url": "/events/777-february-convoy",
+            "created_at": "2023-01-22 18:48:47",
+            "updated_at": "2023-01-24 00:57:01"
+        }
+    ]
+}


### PR DESCRIPTION
Adds support for fetching events created by a user:

* https://github.com/TruckersMP/API-Documentation/pull/1

This one causes a bit of confusion. The API references the user as a player (hence our `Player` model). However, this endpoint uses the user keyword. Though, as our request classes follow the route naming convention, I stuck to that.