### PR TITLE
Support for Carbon v3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "nesbot/carbon": "^2.16",
+        "nesbot/carbon": "^2.16|^3.0",
         "guzzlehttp/guzzle": "^7.3",
         "illuminate/collections": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },


### PR DESCRIPTION
There seem to be no breaking changes between the two versions; supporting them simultaneously should be fine.

Resolves #62.